### PR TITLE
ci: release requires macos

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   release-plz:
     name: Release-plz
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       # Generating a GitHub token, so that PRs and tags created by


### PR DESCRIPTION
We're compiling C code that targets macOS specifically.
