### PR TITLE
Fix mach port + OOL buffer leaks in mach_send_message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use std::{
     error::Error,
     ffi::{CStr, CString},
     fmt,
+    os::raw::c_char,
 };
 
 #[derive(Debug)]
@@ -29,7 +30,7 @@ impl Error for SketchybarError {}
 
 #[link(name = "sketchybar", kind = "static")]
 extern "C" {
-    fn sketchybar(message: *mut i8, bar_name: *mut i8) -> *mut i8;
+    fn sketchybar(message: *mut c_char, bar_name: *mut c_char) -> *mut c_char;
 }
 
 /// Sends a message to `SketchyBar` and returns the response.
@@ -61,6 +62,13 @@ extern "C" {
 /// This function contains unsafe code that calls into a C library (sketchybar).
 /// Ensure the C library is correctly implemented to avoid undefined behavior.
 ///
+/// # Memory ownership
+///
+/// The C side returns a `malloc`'d buffer (or `NULL`). After copying it into
+/// a Rust `String`, this function `libc::free`s the original to avoid leaking
+/// the response buffer on every call. A `NULL` response is mapped to an empty
+/// string for backwards compatibility.
+///
 /// # Examples
 ///
 /// ```no-run
@@ -82,10 +90,26 @@ pub fn message(
     let bar_name = CString::new(bar_name.unwrap_or("sketchybar"))
         .map_err(|_| SketchybarError::MessageConversionError)?;
 
-    let result = unsafe {
-        CStr::from_ptr(sketchybar(command.into_raw(), bar_name.into_raw()))
+    let raw_cmd = command.into_raw();
+    let raw_bar = bar_name.into_raw();
+
+    let response_ptr = unsafe { sketchybar(raw_cmd, raw_bar) };
+
+    // Reclaim the CStrings we handed to C via into_raw().
+    unsafe {
+        let _ = CString::from_raw(raw_cmd);
+        let _ = CString::from_raw(raw_bar);
+    }
+
+    let result = if response_ptr.is_null() {
+        String::new()
+    } else {
+        let s = unsafe { CStr::from_ptr(response_ptr) }
             .to_string_lossy()
-            .into_owned()
+            .into_owned();
+        // Free the malloc'd buffer the C side handed us.
+        unsafe { libc::free(response_ptr.cast::<libc::c_void>()) };
+        s
     };
 
     Ok(result)

--- a/src/sketchybar.h
+++ b/src/sketchybar.h
@@ -4,6 +4,7 @@
 #include <mach/message.h>
 #include <bootstrap.h>
 #include <stdlib.h>
+#include <string.h>
 #include <pthread.h>
 #include <stdio.h>
 
@@ -60,7 +61,7 @@ mach_port_t mach_get_bs_port(char* bar_name) {
     return 0;
   }
 
-  char service_name[256]; // Assuming the service name will not exceed 255 chars
+  char service_name[256];
   snprintf(service_name, sizeof(service_name), "git.felix.%s", bar_name);
 
   mach_port_t port;
@@ -98,13 +99,15 @@ void mach_receive_message(mach_port_t port, struct mach_buffer* buffer, bool tim
   }
 }
 
+// Caller must free() the returned string. Returns NULL on failure or empty
+// response. Fixes upstream leaks: response_port and OOL response buffer.
 char* mach_send_message(mach_port_t port, char* message, uint32_t len) {
   if (!message || !port) {
     return NULL;
   }
 
-  mach_port_t response_port;
   mach_port_name_t task = mach_task_self();
+  mach_port_t response_port;
   if (mach_port_allocate(task, MACH_PORT_RIGHT_RECEIVE,
                                &response_port          ) != KERN_SUCCESS) {
     return NULL;
@@ -112,7 +115,8 @@ char* mach_send_message(mach_port_t port, char* message, uint32_t len) {
 
   if (mach_port_insert_right(task, response_port,
                                    response_port,
-                                   MACH_MSG_TYPE_MAKE_SEND)!= KERN_SUCCESS) {
+                                   MACH_MSG_TYPE_MAKE_SEND) != KERN_SUCCESS) {
+    mach_port_mod_refs(task, response_port, MACH_PORT_RIGHT_RECEIVE, -1);
     return NULL;
   }
 
@@ -143,11 +147,26 @@ char* mach_send_message(mach_port_t port, char* message, uint32_t len) {
 
   struct mach_buffer buffer = { 0 };
   mach_receive_message(response_port, &buffer, true);
-  if (buffer.message.descriptor.address)
-    return (char*)buffer.message.descriptor.address;
+
+  // Copy the OOL response into a heap buffer the caller owns, then destroy
+  // the mach message (which vm_deallocates the OOL region).
+  char* result = NULL;
+  if (buffer.message.descriptor.address
+      && buffer.message.descriptor.size > 0) {
+    size_t sz = buffer.message.descriptor.size;
+    result = (char*)malloc(sz + 1);
+    if (result) {
+      memcpy(result, buffer.message.descriptor.address, sz);
+      result[sz] = '\0';
+    }
+  }
   mach_msg_destroy(&buffer.message.header);
 
-  return NULL;
+  // Drop both rights on response_port so the kernel reclaims it.
+  mach_port_mod_refs(task, response_port, MACH_PORT_RIGHT_SEND, -1);
+  mach_port_mod_refs(task, response_port, MACH_PORT_RIGHT_RECEIVE, -1);
+
+  return result;
 }
 
 #pragma clang diagnostic push
@@ -217,12 +236,7 @@ char* sketchybar(char* message, char* bar_name) {
 
   formatted_message[caret] = '\0';
   if (!g_mach_port) g_mach_port = mach_get_bs_port(bar_name);
-  char* response = mach_send_message(g_mach_port,
-                                     formatted_message,
-                                     caret + 1          );
-
-  if (response) return response;
-  else return (char*)"";
+  return mach_send_message(g_mach_port, formatted_message, caret + 1);
 }
 
 void event_server_begin(mach_handler event_handler, char* bootstrap_name) {


### PR DESCRIPTION
## Problem

Each call to `sketchybar()` (i.e. every `sketchybar_rs::message`) leaks two
kernel resources in `mach_send_message` (`src/sketchybar.h`):

1. **`response_port`** — allocated via `mach_port_allocate(MACH_PORT_RIGHT_RECEIVE)` and granted a SEND right via `mach_port_insert_right(... MAKE_SEND)`, but never released. The two rights remain in the task's port table forever.
2. **OOL response buffer** — the response is returned to the caller as the `mach_msg_ool_descriptor_t` `address` pointer. `mach_msg_destroy` is only called on the failure path, so on every successful call the vm-mapped region the kernel handed us is never `vm_deallocate`'d.

Long-running daemons that use this crate (e.g. one driving sketchybar widgets / pollers) accumulate **~1k mach ports per hour plus unbounded vm pages**. On my workstation a daemon at 11h had 185,741 mach ports and 2.9 GB RSS. The leaked kernel objects show up as elevated `kernel_task` CPU and IPC slowdown long before users notice the leak directly.

## Fix

**C side (`src/sketchybar.h`)**

- Copy the OOL response into a `malloc`'d buffer the caller owns.
- Call `mach_msg_destroy` on success too, so the OOL region is freed.
- Drop both port rights with `mach_port_mod_refs(... -1)` for `RIGHT_SEND` and `RIGHT_RECEIVE` so the kernel reclaims `response_port`.
- On `mach_port_insert_right` failure, also drop the receive right we already allocated.
- Keep the rest of the helper (server begin / receive / sketchybar tokenizer) unchanged.

**Rust side (`src/lib.rs`)**

- After copying the response with `CStr::from_ptr(...).to_string_lossy().into_owned()`, `libc::free` the raw pointer the C side returned.
- Reclaim the two `CString` allocations we handed to C via `into_raw()` (`CString::from_raw`) so we don't leak them either.
- A `NULL` response (now a real possibility on failure) maps to an empty string for backwards compatibility with the previous behavior.

## Verification

A daemon doing CPU/memory/clock/battery/workspace pollers stayed at:

```
t=15s  ports=94   rss=10.9MB    (initial)
t=28s  ports=38   rss=10.0MB
t=40s  ports=38   rss=10.0MB
t=53s  ports=38   rss=10.0MB
t=65s  ports=38   rss=10.0MB    ← flat
```

over multiple sessions, vs unbounded growth before the patch.

## Notes

The same buggy pattern lives in `FelixKratz/SketchyBar`'s helper headers (where this code was originally derived from); maintainers there may want a parallel fix.